### PR TITLE
My changes to the original headers

### DIFF
--- a/TestOpcUa.lpi
+++ b/TestOpcUa.lpi
@@ -80,6 +80,11 @@
             <Debugging>
               <StripSymbols Value="True"/>
             </Debugging>
+            <Options>
+              <Win32>
+                <GraphicApplication Value="True"/>
+              </Win32>
+            </Options>
           </Linking>
         </CompilerOptions>
       </Item4>

--- a/TestOpcUa.lpi
+++ b/TestOpcUa.lpi
@@ -13,9 +13,8 @@
       <XPManifest>
         <DpiAware Value="True"/>
       </XPManifest>
-      <Icon Value="0"/>
     </General>
-    <BuildModes Count="3">
+    <BuildModes Count="4">
       <Item1 Name="Win32" Default="True"/>
       <Item2 Name="Win64">
         <CompilerOptions>
@@ -66,6 +65,24 @@
           </Linking>
         </CompilerOptions>
       </Item3>
+      <Item4 Name="Default">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="TestOpcUa"/>
+          </Target>
+          <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
+            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Linking>
+            <Debugging>
+              <StripSymbols Value="True"/>
+            </Debugging>
+          </Linking>
+        </CompilerOptions>
+      </Item4>
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>

--- a/TestOpcUa.lpr
+++ b/TestOpcUa.lpr
@@ -16,7 +16,7 @@ begin
   RequireDerivedFormResource:=True;
   Application.Scaled:=True;
   Application.Initialize;
-  Application.CreateForm(TForm1, Form1);
+  Application.CreateForm(TTestOpcUaForm, TestOpcUaForm);
   Application.Run;
 end.
 

--- a/TestOpcUa.lpr
+++ b/TestOpcUa.lpr
@@ -3,9 +3,9 @@ program TestOpcUa;
 {$mode objfpc}{$H+}
 
 uses
-  {$IFDEF UNIX}{$IFDEF UseCThreads}
+  {$IFDEF UNIX}
   cthreads,
-  {$ENDIF}{$ENDIF}
+  {$ENDIF}
   Interfaces, // this includes the LCL widgetset
   Forms, TestOpcUa1
   { you can add units after this };

--- a/TestOpcUa1.lfm
+++ b/TestOpcUa1.lfm
@@ -7,6 +7,8 @@ object TestOpcUaForm: TTestOpcUaForm
   ClientHeight = 525
   ClientWidth = 541
   OnClose = FormClose
+  OnCreate = FormCreate
+  OnDestroy = FormDestroy
   LCLVersion = '2.0.10.0'
   object Memo1: TMemo
     Left = 8
@@ -22,7 +24,7 @@ object TestOpcUaForm: TTestOpcUaForm
     Height = 66
     Top = 448
     Width = 521
-    Anchors = [akTop, akLeft, akRight]
+    Anchors = [akLeft, akRight, akBottom]
     ScrollBars = ssVertical
     TabOrder = 1
   end
@@ -179,7 +181,7 @@ object TestOpcUaForm: TTestOpcUaForm
     end
     object tabServer: TTabSheet
       Caption = 'OPC UA Server'
-      ClientHeight = 228
+      ClientHeight = 230
       ClientWidth = 517
       object btnServerStart: TToggleBox
         Left = 434
@@ -201,9 +203,9 @@ object TestOpcUaForm: TTestOpcUaForm
         TabOrder = 1
         object lNamespace1: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 16
-          Width = 62
+          Width = 55
           Caption = 'Namespace'
           ParentColor = False
         end
@@ -223,15 +225,15 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object lVariableName: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 40
-          Width = 75
+          Width = 67
           Caption = 'Variable name'
           ParentColor = False
         end
         object eServerVariableName: TEdit
           Left = 96
-          Height = 23
+          Height = 21
           Top = 32
           Width = 312
           TabOrder = 1
@@ -239,15 +241,15 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object lNodeValue1: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 96
-          Width = 29
+          Width = 26
           Caption = 'Value'
           ParentColor = False
         end
         object eServerVariableValue: TEdit
           Left = 96
-          Height = 23
+          Height = 21
           Top = 88
           Width = 312
           TabOrder = 3

--- a/TestOpcUa1.lfm
+++ b/TestOpcUa1.lfm
@@ -7,7 +7,7 @@ object TestOpcUaForm: TTestOpcUaForm
   ClientHeight = 525
   ClientWidth = 541
   OnClose = FormClose
-  LCLVersion = '2.0.6.0'
+  LCLVersion = '2.0.10.0'
   object Memo1: TMemo
     Left = 8
     Height = 170
@@ -37,22 +37,22 @@ object TestOpcUaForm: TTestOpcUaForm
     TabOrder = 2
     object tabClient: TTabSheet
       Caption = 'OPC UA Client'
-      ClientHeight = 228
+      ClientHeight = 230
       ClientWidth = 517
       object Label1: TLabel
         Left = 8
-        Height = 15
+        Height = 13
         Top = 16
-        Width = 78
+        Width = 73
         Caption = 'OPC UA Server'
         ParentColor = False
       end
       object cbServer: TComboBox
         Left = 96
-        Height = 23
+        Height = 21
         Top = 12
         Width = 324
-        ItemHeight = 15
+        ItemHeight = 13
         Items.Strings = (
           'opc.tcp://localhost:53530/OPCUA/SimulationServer'
           'opc.tcp://localhost:4840/'
@@ -76,23 +76,23 @@ object TestOpcUaForm: TTestOpcUaForm
         Top = 48
         Width = 513
         Caption = 'Variables'
-        ClientHeight = 156
+        ClientHeight = 158
         ClientWidth = 509
         TabOrder = 2
         object lNamespace: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 16
-          Width = 62
+          Width = 55
           Caption = 'Namespace'
           ParentColor = False
         end
         object cbNS: TComboBox
           Left = 96
-          Height = 23
+          Height = 21
           Top = 8
           Width = 48
-          ItemHeight = 15
+          ItemHeight = 13
           ItemIndex = 1
           Items.Strings = (
             '1'
@@ -106,18 +106,18 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object lNodeType: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 40
-          Width = 71
+          Width = 65
           Caption = 'Node Id Type'
           ParentColor = False
         end
         object cbNodeType: TComboBox
           Left = 96
-          Height = 23
+          Height = 21
           Top = 32
           Width = 72
-          ItemHeight = 15
+          ItemHeight = 13
           ItemIndex = 1
           Items.Strings = (
             'numeric'
@@ -129,15 +129,15 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object lNodeId: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 68
-          Width = 42
+          Width = 38
           Caption = 'Node Id'
           ParentColor = False
         end
         object eNodeId: TEdit
           Left = 96
-          Height = 23
+          Height = 21
           Top = 60
           Width = 312
           TabOrder = 2
@@ -162,15 +162,15 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object lNodeValue: TLabel
           Left = 11
-          Height = 15
+          Height = 13
           Top = 96
-          Width = 29
+          Width = 26
           Caption = 'Value'
           ParentColor = False
         end
         object eNodeValue: TEdit
           Left = 96
-          Height = 23
+          Height = 21
           Top = 88
           Width = 312
           TabOrder = 3
@@ -196,7 +196,7 @@ object TestOpcUaForm: TTestOpcUaForm
         Top = 48
         Width = 513
         Caption = 'Variable'
-        ClientHeight = 156
+        ClientHeight = 158
         ClientWidth = 509
         TabOrder = 1
         object lNamespace1: TLabel
@@ -209,10 +209,10 @@ object TestOpcUaForm: TTestOpcUaForm
         end
         object cbServerNS: TComboBox
           Left = 96
-          Height = 23
+          Height = 21
           Top = 8
           Width = 48
-          ItemHeight = 15
+          ItemHeight = 13
           ItemIndex = 0
           Items.Strings = (
             '1'

--- a/TestOpcUa1.pas
+++ b/TestOpcUa1.pas
@@ -194,7 +194,7 @@ begin
 
 
   (*** Connection - Anonymous user, Security None ***)
-  res := UA_Client_connect(client, PAnsiChar(cbServer.Text));
+  res := UA_Client_connect(client, cbServer.Text);
   //res := UA_Client_connectUsername(client, PAnsiChar(cbServer.Text),'test','test');
   if res <> UA_STATUSCODE_GOOD then begin
     Memo1.Lines.Append(Format('Fail status code: %x %s', [res, AnsiString(UA_StatusCode_name(res))]));
@@ -346,7 +346,7 @@ begin
 
   case cbNodeType.ItemIndex of
     0:   NodeId := UA_NODEID_NUMERIC(StrToInt(cbNS.Text), StrToInt(eNodeId.Text));
-    else NodeId := UA_NODEID_STRING_ALLOC(StrToInt(cbNS.Text), PAnsiChar(AnsiString(eNodeId.Text)));
+    else NodeId := UA_NODEID_STRING_ALLOC(StrToInt(cbNS.Text), eNodeId.Text);
   end;
 
   // get data type of requested variable
@@ -437,7 +437,7 @@ begin
 
   case cbNodeType.ItemIndex of
     0:   NodeId := UA_NODEID_NUMERIC(StrToInt(cbNS.Text), StrToInt(eNodeId.Text));
-    else NodeId := UA_NODEID_STRING(StrToInt(cbNS.Text), PAnsiChar(eNodeId.Text));
+    else NodeId := UA_NODEID_STRING_ALLOC(StrToInt(cbNS.Text), eNodeId.Text);
   end;
 
   // check varible Data Type on server
@@ -513,19 +513,23 @@ var
   intVariableNodeId, parentNodeId, parentReferenceNodeId: UA_NodeId;
   intVariableName: UA_QualifiedName;
   res: UA_StatusCode;
+  varlang:AnsiString;
+  varname:AnsiString;
 begin
+  varlang:='en-US';
+  varname:=eServerVariableName.Text;
   (* Define the attribute of the myInteger variable node *)
   attr := UA_VariableAttributes_default;
   intVariable := StrToInt(eServerVariableValue.Text);
   UA_Variant_setScalar(@attr.value, @intVariable, @UA_TYPES[UA_TYPES_INT32]);
-  attr.description := _UA_LOCALIZEDTEXT('en-US', PAnsiChar(eServerVariableName.Text));
-  attr.displayName := _UA_LOCALIZEDTEXT('en-US', PAnsiChar(eServerVariableName.Text));
+  attr.description := _UA_LOCALIZEDTEXT(varlang, varname);
+  attr.displayName := _UA_LOCALIZEDTEXT(varlang, varname);
   attr.dataType := UA_TYPES[UA_TYPES_INT32].typeId;
   attr.accessLevel := UA_ACCESSLEVELMASK_READ or UA_ACCESSLEVELMASK_WRITE;
 
   (* Add the variable node to the information model *)
-  intVariableNodeId := UA_NODEID_STRING(StrToInt(cbServerNS.Text){name space index}, PAnsiChar(eServerVariableName.Text));
-  intVariableName := _UA_QUALIFIEDNAME(StrToInt(cbServerNS.Text), PAnsiChar(eServerVariableName.Text));
+  intVariableNodeId := UA_NODEID_STRING(StrToInt(cbServerNS.Text){name space index}, varname);
+  intVariableName := _UA_QUALIFIEDNAME(StrToInt(cbServerNS.Text), varname);
   parentNodeId := UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
   parentReferenceNodeId := UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
   res := UA_Server_addVariableNode(server, intVariableNodeId, parentNodeId,
@@ -540,11 +544,12 @@ var
   value: UA_Variant;
   res: UA_StatusCode;
 begin
-  intVariableNodeId := UA_NODEID_STRING(StrToInt(cbServerNS.Text){name space index}, PAnsiChar(eServerVariableName.Text));
+  intVariableNodeId := UA_NODEID_STRING_ALLOC(StrToInt(cbServerNS.Text){name space index}, eServerVariableName.Text);
   UA_Variant_init(value);
   UA_Variant_setInteger(value, StrToInt(eServerVariableValue.Text));
   res := UA_Server_writeValue(server, intVariableNodeId, value);
   Memo1.Lines.Append(Format('Server write to variable "%s" (Result=%x)', [eServerVariableName.Text, res]));
+  UA_NodeId_clear(intVariableNodeId);
 end;
 
 end.

--- a/fpopen65241.lpk
+++ b/fpopen65241.lpk
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <Package Version="4">
+    <PathDelim Value="\"/>
+    <Name Value="fpopen65241"/>
+    <CompilerOptions>
+      <Version Value="11"/>
+      <PathDelim Value="\"/>
+      <SearchPaths>
+        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)\"/>
+      </SearchPaths>
+    </CompilerOptions>
+    <Files Count="1">
+      <Item1>
+        <Filename Value="open62541.pas"/>
+        <UnitName Value="open62541"/>
+      </Item1>
+    </Files>
+    <RequiredPkgs Count="1">
+      <Item1>
+        <PackageName Value="FCL"/>
+      </Item1>
+    </RequiredPkgs>
+    <UsageOptions>
+      <UnitPath Value="$(PkgOutDir)"/>
+    </UsageOptions>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+  </Package>
+</CONFIG>

--- a/open62541.pas
+++ b/open62541.pas
@@ -1365,7 +1365,7 @@ var
   UA_ClientConfig_setDefault: function(config: PUA_ClientConfig): UA_StatusCode; cdecl;
   UA_ClientConfig_setDefaultEncryption: function(config: PUA_ClientConfig; localCertificate, privateKey: UA_ByteString; trustList: PUA_ByteString; trustListSize: size_t; revocationList: PUA_ByteString; revocationListSize: size_t): UA_StatusCode; cdecl;
   UA_Client_delete: procedure(client: PUA_Client); cdecl;
-  UA_Client_connect: function(client: PUA_Client; endpointUrl: PAnsiChar): UA_StatusCode; cdecl;
+  UA_Client_connect: function(client: PUA_Client; const endpointUrl: AnsiString): UA_StatusCode; cdecl;
   UA_Client_disconnect: function(client: PUA_Client): UA_StatusCode; cdecl;
   __UA_Client_Service: procedure(client: PUA_Client; const request: Pointer; const requestType: PUA_DataType; response: Pointer; const responseType: PUA_DataType); cdecl;
   UA_Client_run_iterate: function(client: PUA_Client; timeout: UA_UInt32): UA_StatusCode; cdecl;
@@ -1486,7 +1486,7 @@ procedure UA_Client_delete(client: PUA_Client); cdecl; external libopen62541;
  * @param client to use
  * @param endpointURL to connect (for example "opc.tcp://localhost:4840")
  * @return Indicates whether the operation succeeded or returns an error code *)
-function UA_Client_connect(client: PUA_Client; endpointUrl: PAnsiChar): UA_StatusCode; cdecl; external libopen62541;
+function UA_Client_connect(client: PUA_Client; const endpointUrl: AnsiString): UA_StatusCode; cdecl; external libopen62541;
 (* Connect to the selected server with the given username and password *)
 //function UA_Client_connect_username(client: PUA_Client; endpointUrl: PAnsiChar; username, password: PAnsiChar): UA_StatusCode; cdecl; external libopen62541; deprecated;
 (* Disconnect and close a connection to the selected server *)
@@ -1686,16 +1686,19 @@ function __UA_Server_write(server: PUA_Server; const nodeId: PUA_NodeId; const a
 { --------------- }
 { --- types.h --- }
 { --------------- }
+{ the non allocating versions use 'var' to emphasize that not a copy but the
+  original value is used (and it shouldn't be changed)  and to make it
+  impossible to use a property as an actual parameter }
 function _UA_StatusCode_Name(code: UA_StatusCode): AnsiString;
-function _UA_STRING(chars: PAnsiChar): UA_String;
-function _UA_STRING_ALLOC(chars: PAnsiChar): UA_String; inline;
-function _UA_BYTESTRING(chars: PAnsiChar): UA_ByteString; inline;
-function _UA_BYTESTRING_ALLOC(chars: PAnsiChar): UA_ByteString; inline;
-function _UA_QUALIFIEDNAME(nsIndex: UA_UInt16; chars: PAnsiChar): UA_QualifiedName;
-function _UA_QUALIFIEDNAME_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_QualifiedName; inline;
-function _UA_LOCALIZEDTEXT(locale, text: PAnsiChar): UA_LocalizedText;
-function _UA_LOCALIZEDTEXT_ALLOC(locale, text: PAnsiChar): UA_LocalizedText; inline;
-function _UA_NUMERICRANGE(s: PAnsiChar): UA_NumericRange;
+function _UA_STRING(var chars: AnsiString): UA_String; inline;
+function _UA_STRING_ALLOC(const chars: AnsiString): UA_String; inline;
+function _UA_BYTESTRING(var chars: AnsiString): UA_ByteString; inline;
+function _UA_BYTESTRING_ALLOC(const chars: AnsiString): UA_ByteString; inline;
+function _UA_QUALIFIEDNAME(nsIndex: UA_UInt16; var chars: AnsiString): UA_QualifiedName;
+function _UA_QUALIFIEDNAME_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_QualifiedName; inline;
+function _UA_LOCALIZEDTEXT(var locale, text: AnsiString): UA_LocalizedText;
+function _UA_LOCALIZEDTEXT_ALLOC(const locale, text: AnsiString): UA_LocalizedText; inline;
+function _UA_NUMERICRANGE(const s: AnsiString): UA_NumericRange;
 function _UA_String_equal(const s1: UA_String; const s2: AnsiString):boolean; overload;
 
 (* my helper functions *)
@@ -1726,15 +1729,15 @@ procedure UA_Variant_setByte(out v: UA_Variant; i: Byte);
 procedure UA_Variant_setSmallint(out v: UA_Variant; i: Smallint);
 procedure UA_Variant_setInteger(out v: UA_Variant; i: Integer);
 procedure UA_Variant_setInt64(out v: UA_Variant; i: Int64);
-procedure UA_Variant_setString(out v: UA_Variant; s: AnsiString);
+procedure UA_Variant_setString(out v: UA_Variant; const s: AnsiString);
 
 (* The following functions are shorthand for creating NodeIds. *)
 function UA_NODEID_NUMERIC(nsIndex: UA_UInt16; identifier: UA_UInt32): UA_NodeId;
-function UA_NODEID_STRING(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
-function UA_NODEID_STRING_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_STRING(nsIndex: UA_UInt16; var chars: AnsiString): UA_NodeId;
+function UA_NODEID_STRING_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_NodeId;
 function UA_NODEID_GUID(nsIndex: UA_UInt16; guid: UA_Guid): UA_NodeId;
-function UA_NODEID_BYTESTRING(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
-function UA_NODEID_BYTESTRING_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_BYTESTRING(nsIndex: UA_UInt16; var chars: AnsiString): UA_NodeId;
+function UA_NODEID_BYTESTRING_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_NodeId;
 
 (* Test if the data type is a numeric builtin data type. This includes Boolean,
  * integers and floating point numbers. Not included are DateTime and StatusCode. *)
@@ -1752,11 +1755,32 @@ procedure UA_NodeId_clear(var p: UA_NodeId);
 procedure UA_CreateSubscriptionRequest_init(out p: UA_CreateSubscriptionRequest);
 procedure UA_MonitoredItemCreateRequest_init(out p: UA_MonitoredItemCreateRequest);
 
+procedure UA_BrowseRequest_init(out p: UA_BrowseRequest);
+function UA_BrowseRequest_new:PUA_BrowseRequest;
+function UA_BrowseRequest_copy(const src: UA_BrowseRequest; out dst:UA_BrowseRequest): UA_StatusCode;
+procedure UA_BrowseRequest_deleteMembers(var p: UA_BrowseRequest);
+procedure UA_BrowseRequest_clear(var p: UA_BrowseRequest);
+procedure UA_BrowseRequest_delete(p: PUA_BrowseRequest);
+
+procedure UA_BrowseResponse_init(out p: UA_BrowseResponse);
+function UA_BrowseResponse_new:PUA_BrowseResponse;
+function UA_BrowseResponse_copy(const src: UA_BrowseResponse; out dst:UA_BrowseResponse): UA_StatusCode;
+procedure UA_BrowseResponse_deleteMembers(var p: UA_BrowseResponse);
+procedure UA_BrowseResponse_clear(var p: UA_BrowseResponse);
+procedure UA_BrowseResponse_delete(p: PUA_BrowseResponse);
+
+procedure UA_BrowseDescription_init(out p: UA_BrowseDescription);
+function UA_BrowseDescription_new:PUA_BrowseDescription;
+function UA_BrowseDescription_copy(const src: UA_BrowseDescription; out dst:UA_BrowseDescription): UA_StatusCode;
+procedure UA_BrowseDescription_deleteMembers(var p: UA_BrowseDescription);
+procedure UA_BrowseDescription_clear(var p: UA_BrowseDescription);
+procedure UA_BrowseDescription_delete(p: PUA_BrowseDescription);
+
 { ---------------- }
 { --- client.h --- }
 { ---------------- }
-function UA_Client_connect_username(client: PUA_Client; endpointUrl: PAnsiChar; username, password: PAnsiChar): UA_StatusCode; deprecated;
-function UA_Client_connectUsername(client: PUA_Client; endpointUrl: PAnsiChar; username, password: PAnsiChar): UA_StatusCode;
+function UA_Client_connect_username(client: PUA_Client; const endpointUrl, username, password: AnsiString): UA_StatusCode; deprecated;
+function UA_Client_connectUsername(client: PUA_Client; const endpointUrl, username, password: AnsiString): UA_StatusCode;
 function UA_Client_Service_read(client: PUA_Client; const request: UA_ReadRequest): UA_ReadResponse;
 function UA_Client_Service_browse(client: PUA_Client; const request: UA_BrowseRequest): UA_BrowseResponse;
 
@@ -1844,7 +1868,7 @@ begin
                                   [libopen62541, GetLoadErrorStr()]);
     end;
 
-    UA_TYPES := PUA_DataType(GetProcedureAddress(open62541LibHandle,'UA_TYPES')); // external variable name
+    pointer(UA_TYPES) := GetProcedureAddress(open62541LibHandle,'UA_TYPES'); // external variable name
     UA_VariableAttributes_default := PUA_VariableAttributes(GetProcedureAddress(open62541LibHandle,'UA_VariableAttributes_default'))^;
 
     @UA_Client_new := GetProcedureAddress(open62541LibHandle,'UA_Client_new');
@@ -1929,76 +1953,86 @@ end;
  * ``UA_STRING`` returns a string pointing to the original char-array.
  * ``UA_STRING_ALLOC`` is shorthand for ``UA_String_fromChars`` and makes a copy
  * of the char-array. *)
-function _UA_STRING(chars: PAnsiChar): UA_String;
+function _UA_STRING(var chars: AnsiString): UA_String; inline;
 begin
-  if chars=nil then begin
+  if chars='' then begin
     Result.length := 0;
     Result.data := nil;
   end
   else begin
-    Result.length := StrLen(chars);
-    Result.data := PUA_Byte(chars);
+    Result.length := Length(chars);
+    Result.data := @chars[1];
   end;
 end;
 
-function _UA_STRING_ALLOC(chars: PAnsiChar): UA_String; inline;
+function _UA_STRING_ALLOC(const chars: AnsiString): UA_String; inline;
+var bs:UA_BYTESTRING;
 begin
-  Result := UA_String_fromChars(chars);
-end;
-
-function _UA_BYTESTRING(chars: PAnsiChar): UA_ByteString;
+  if chars='' then
 begin
-  if chars=nil then begin
-    Result.length := 0;
-    Result.data := nil;
-  end
-  else begin
-    Result.length := StrLen(chars);
-    Result.data := PUA_Byte(chars);
+    result.length:=0;
+    result.data:=Nil;
+  end else
+  begin
+    //this contortion is necessary in order to let the library allocate the memory
+    //(the C and pascal alloc/free cannot be mixed)
+    bs.length:=length(chars);
+    bs.data:=@chars[1];
+    UA_copy(@bs, @result, @UA_TYPES[UA_TYPES_BYTESTRING]);
   end;
 end;
 
-function _UA_BYTESTRING_ALLOC(chars: PAnsiChar): UA_ByteString;
+function _UA_BYTESTRING(var chars: AnsiString): UA_ByteString;
 begin
-  Result := UA_String_fromChars(chars);
+  result:=UA_ByteString(_UA_STRING(chars));
 end;
 
-function _UA_QUALIFIEDNAME(nsIndex: UA_UInt16; chars: PAnsiChar): UA_QualifiedName;
+function _UA_BYTESTRING_ALLOC(const chars: AnsiString): UA_ByteString; inline;
+begin
+  result:=UA_ByteString(_UA_STRING_ALLOC(chars));
+end;
+
+function _UA_QUALIFIEDNAME(nsIndex: UA_UInt16; var chars: AnsiString): UA_QualifiedName;
 begin
   Result.namespaceIndex := nsIndex;
   Result.name := _UA_STRING(chars);
 end;
 
-function _UA_QUALIFIEDNAME_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_QualifiedName;
+function _UA_QUALIFIEDNAME_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_QualifiedName;
 begin
   Result.namespaceIndex := nsIndex;
   Result.name := _UA_STRING_ALLOC(chars);
 end;
 
-function _UA_LOCALIZEDTEXT(locale, text: PAnsiChar): UA_LocalizedText;
+function _UA_LOCALIZEDTEXT(var locale, text: AnsiString): UA_LocalizedText;
 begin
   Result.locale := _UA_STRING(locale);
   Result.text := _UA_STRING(text);
 end;
 
-function _UA_LOCALIZEDTEXT_ALLOC(locale, text: PAnsiChar): UA_LocalizedText;
+function _UA_LOCALIZEDTEXT_ALLOC(const locale, text: AnsiString): UA_LocalizedText;
 begin
   Result.locale := _UA_STRING_ALLOC(locale);
   Result.text := _UA_STRING_ALLOC(text)
 end;
 
-function _UA_NUMERICRANGE(s: PAnsiChar): UA_NumericRange;
+function _UA_NUMERICRANGE(const s: AnsiString): UA_NumericRange;
+var
+  uas:UA_String;
 begin
   Result.dimensionsSize := 0;
   Result.dimensions := nil;
-  UA_NumericRange_parse(@Result, _UA_STRING(s));
+  uas:=_UA_STRING_ALLOC(s);
+  UA_NumericRange_parse(@Result, uas);
+  UA_String_clear(uas);
 end;
 
 function _UA_String_equal(const s1: UA_String; const s2: AnsiString):boolean; overload;
 var s: UA_String;
 begin
-  s := _UA_STRING(PAnsiChar(s2));
+  s := _UA_STRING_ALLOC(s2);
   Result:=UA_String_equal(@s1,@s);
+  UA_String_clear(s);
 end;
 
 function UA_StringToStr(const s: UA_String): AnsiString;
@@ -2055,6 +2089,99 @@ end;
 procedure UA_MonitoredItemCreateRequest_init(out p: UA_MonitoredItemCreateRequest);
 begin
   FillChar(p, SizeOf(p), #0);
+end;
+
+procedure UA_BrowseRequest_init(out p: UA_BrowseRequest);
+begin
+  FillChar(p, SizeOf(p), #0);
+end;
+
+function UA_BrowseRequest_new: PUA_BrowseRequest;
+begin
+  result:= UA_new(@UA_TYPES[UA_TYPES_BROWSEREQUEST]);
+end;
+
+function UA_BrowseRequest_copy(const src: UA_BrowseRequest; out
+  dst: UA_BrowseRequest): UA_StatusCode;
+begin
+  result:=UA_copy(@src, @dst, @UA_TYPES[UA_TYPES_BROWSEREQUEST]);
+end;
+
+procedure UA_BrowseRequest_deleteMembers(var p: UA_BrowseRequest);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSEREQUEST]);
+end;
+
+procedure UA_BrowseRequest_clear(var p: UA_BrowseRequest);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSEREQUEST]);
+end;
+
+procedure UA_BrowseRequest_delete(p: PUA_BrowseRequest);
+begin
+  UA_delete(p, @UA_TYPES[UA_TYPES_BROWSEREQUEST]);
+end;
+
+procedure UA_BrowseResponse_init(out p: UA_BrowseResponse);
+begin
+  FillChar(p, SizeOf(p), #0);
+end;
+
+function UA_BrowseResponse_new: PUA_BrowseResponse;
+begin
+  result:= UA_new(@UA_TYPES[UA_TYPES_BROWSERESPONSE]);
+end;
+
+function UA_BrowseResponse_copy(const src: UA_BrowseResponse; out
+  dst: UA_BrowseResponse): UA_StatusCode;
+begin
+  result:=UA_copy(@src, @dst, @UA_TYPES[UA_TYPES_BROWSERESPONSE]);
+end;
+
+procedure UA_BrowseResponse_deleteMembers(var p: UA_BrowseResponse);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSERESPONSE]);
+end;
+
+procedure UA_BrowseResponse_clear(var p: UA_BrowseResponse);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSERESPONSE]);
+end;
+
+procedure UA_BrowseResponse_delete(p: PUA_BrowseResponse);
+begin
+  UA_delete(p, @UA_TYPES[UA_TYPES_BROWSERESPONSE]);
+end;
+
+procedure UA_BrowseDescription_init(out p: UA_BrowseDescription);
+begin
+  FillChar(p, SizeOf(p), #0);
+end;
+
+function UA_BrowseDescription_new: PUA_BrowseDescription;
+begin
+  result:= UA_new(@UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
+end;
+
+function UA_BrowseDescription_copy(const src: UA_BrowseDescription; out
+  dst: UA_BrowseDescription): UA_StatusCode;
+begin
+  result:=UA_copy(@src, @dst, @UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
+end;
+
+procedure UA_BrowseDescription_deleteMembers(var p: UA_BrowseDescription);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
+end;
+
+procedure UA_BrowseDescription_clear(var p: UA_BrowseDescription);
+begin
+  UA_clear(@p, @UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
+end;
+
+procedure UA_BrowseDescription_delete(p: PUA_BrowseDescription);
+begin
+  UA_delete(p, @UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
 end;
 
 function UA_Variant_isEmpty(const v: PUA_Variant): Boolean;
@@ -2129,11 +2256,12 @@ procedure UA_Variant_setInt64(out v: UA_Variant; i: Int64);
 begin
   UA_Variant_setScalarCopy(@v, @i, @UA_TYPES[UA_TYPES_INT64]);
 end;
-procedure UA_Variant_setString(out v: UA_Variant; s: AnsiString);
+procedure UA_Variant_setString(out v: UA_Variant; const s: AnsiString);
 var uas: UA_STRING;
 begin
-  uas := _UA_STRING(PAnsiChar(s));
+  uas := _UA_STRING_ALLOC(s);
   UA_Variant_setScalarCopy(@v, @uas, @UA_TYPES[UA_TYPES_STRING]);
+  UA_String_clear(uas);
 end;
 
 function UA_NODEID_NUMERIC(nsIndex: UA_UInt16; identifier: UA_UInt32): UA_NodeId;
@@ -2143,13 +2271,13 @@ begin
   Result.identifier.numeric := identifier;
 end;
 
-function UA_NODEID_STRING(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_STRING(nsIndex: UA_UInt16; var chars: AnsiString): UA_NodeId;
 begin
   Result.namespaceIndex := nsIndex;
   Result.identifierType := UA_NODEIDTYPE_STRING;
   Result.identifier._string := _UA_STRING(chars);
 end;
-function UA_NODEID_STRING_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_STRING_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_NodeId;
 begin
   Result.namespaceIndex := nsIndex;
   Result.identifierType := UA_NODEIDTYPE_STRING;
@@ -2163,13 +2291,13 @@ begin
   Result.identifier.guid := guid;
 end;
 
-function UA_NODEID_BYTESTRING(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_BYTESTRING(nsIndex: UA_UInt16; var chars: AnsiString): UA_NodeId;
 begin
   Result.namespaceIndex := nsIndex;
   Result.identifierType := UA_NODEIDTYPE_BYTESTRING;
   Result.identifier.byteString := _UA_BYTESTRING(chars);
 end;
-function UA_NODEID_BYTESTRING_ALLOC(nsIndex: UA_UInt16; chars: PAnsiChar): UA_NodeId;
+function UA_NODEID_BYTESTRING_ALLOC(nsIndex: UA_UInt16; const chars: AnsiString): UA_NodeId;
 begin
   Result.namespaceIndex := nsIndex;
   Result.identifierType := UA_NODEIDTYPE_BYTESTRING;
@@ -2181,14 +2309,14 @@ begin
   FillChar(p^, _type^.memSize, #0);
 end;
 
-function UA_Client_connect_username(client: PUA_Client; endpointUrl: PAnsiChar; username, password: PAnsiChar): UA_StatusCode;
+function UA_Client_connect_username(client: PUA_Client; const endpointUrl, username, password: AnsiString): UA_StatusCode;
 begin
   Result := UA_Client_connectUsername(client, endpointUrl, username, password);
 end;
 (* Connect to the server and create+activate a Session with the given username
  * and password. This first set the UserIdentityToken in the client config and
  * then calls the regular connect method. *)
-function UA_Client_connectUsername(client: PUA_Client; endpointUrl: PAnsiChar; username, password: PAnsiChar): UA_StatusCode;
+function UA_Client_connectUsername(client: PUA_Client; const endpointUrl, username, password: AnsiString): UA_StatusCode;
 var
   identityToken: PUA_UserNameIdentityToken;
   cc: PUA_ClientConfig;
@@ -2234,7 +2362,7 @@ begin
   FillChar(item, sizeof(UA_ReadValueId), #0);
   item.nodeId := nodeId;
   item.attributeId := ord(UA_ATTRIBUTEID_VALUE);
-  item.indexRange := _UA_STRING(PAnsiChar(indexRange));
+  item.indexRange := _UA_STRING_ALLOC(indexRange);
   FillChar(request, sizeof(UA_ReadRequest), #0);
   request.nodesToRead := @item;
   request.nodesToReadSize := 1;
@@ -2263,6 +2391,7 @@ begin
   end;
 
   UA_clear(@response, @UA_TYPES[UA_TYPES_READRESPONSE]);
+  UA_String_clear(item.indexRange);
 end;
 
 function UA_Client_readValueAttribute(client: PUA_Client; const nodeId: UA_NodeId; out outValue: Byte): UA_StatusCode;
@@ -2371,9 +2500,10 @@ end;
 function UA_Client_writeValueAttribute(client: PUA_Client; const nodeId: UA_NodeId; const newValue: AnsiString): UA_StatusCode;
 var uav: UA_Variant; uas: UA_String;
 begin
-  uas := _UA_STRING(PAnsiChar(newValue));
+  uas := _UA_STRING_ALLOC(newValue);
   UA_Variant_setScalar(@uav, @uas, @UA_TYPES[UA_TYPES_STRING]);
   Result := UA_Client_writeValueAttribute(client, nodeId, uav);
+  UA_String_clear(uas);
 end;
 
 function UA_Client_writeValueAttribute(client: PUA_Client; const nodeId: UA_NodeId; const newValues: array of AnsiString): UA_StatusCode;
@@ -2381,9 +2511,11 @@ var uav: UA_Variant; uas: array of UA_String; i: integer;
 begin
   SetLength(uas, Length(newValues));
   for i:=Low(newValues) to High(newValues) do
-    uas[i] := _UA_STRING(PAnsiChar(newValues[i]));
+    uas[i] := _UA_STRING_ALLOC(newValues[i]);
   UA_Variant_setArray(@uav, @uas[0], Length(uas), @UA_TYPES[UA_TYPES_STRING]);
   Result := UA_Client_writeValueAttribute(client, nodeId, uav);
+  for i:=Low(newValues) to High(newValues) do
+    UA_String_clear(uas[i]);
 end;
 
 function UA_Client_writeDescriptionAttribute(client: PUA_Client; const nodeId: UA_NodeId; {$IFDEF FPC}constref{$ELSE}const{$ENDIF} newDescription: UA_LocalizedText): UA_StatusCode;

--- a/open62541.pas
+++ b/open62541.pas
@@ -1221,7 +1221,10 @@ type
   { --- server_config.h --- }
   { ----------------------- }
   UA_ServerConfig = record
+      nThreads:UA_UInt16; //only if multithreading is enabled
+      logger:UA_Logger;
   {
+    FIXME define the remaining fields
   }
   end;
   PUA_ServerConfig = ^UA_ServerConfig;

--- a/pascallog/pascallog.c
+++ b/pascallog/pascallog.c
@@ -1,0 +1,64 @@
+#include <open62541/plugin/log.h>
+#include <open62541/types.h>
+//gcc -fPIC -I /home/luca/Datos/open62541/open62541-linux64/include/ -shared -o libua_pascallog.so pascallog.c
+
+#if defined(_WIN32)
+#  ifdef __GNUC__
+#   define SYM_EXPORT __attribute__ ((dllexport))
+#  else
+#   define SYM_EXPORT __declspec(dllexport)
+#  endif
+#else /* non win32 */
+# if __GNUC__ || __clang__
+#  define SYM_EXPORT __attribute__ ((visibility ("default")))
+# endif
+#endif
+#ifndef SYM_EXPORT
+# define SYM_EXPORT /* fallback to default */
+#endif
+
+#define LOGBUFSIZE 1024
+
+
+/* function prototype for pascal logging function */
+typedef void (*pascal_log_t) (void *context, UA_LogLevel level, UA_LogCategory category, const char *msg);
+
+/* struct to hold both the original context and the logging function */
+typedef struct PascalLogTrampoline {
+  pascal_log_t func;
+  void * context;
+} PascalLogTrampoline;
+
+/*
+freepascal doesn't allow to define a callback function with c compatible varargs,
+this function formats the message and the args in a buffer then
+calls the pascal function without varargs
+*/
+
+static void
+UA_Log_Pascal_log(void *context, UA_LogLevel level, UA_LogCategory category,
+                  const char *msg, va_list args) {
+        char logbuf[LOGBUFSIZE];
+        if (context != NULL) {
+            PascalLogTrampoline *trampoline = context;
+            vsnprintf(logbuf, LOGBUFSIZE, msg, args);
+            trampoline->func(trampoline->context, level, category, logbuf);
+        }
+}
+
+static void
+UA_Log_Pascal_clear(void *context) {
+        free(context);
+}
+
+/*
+Initializes a logger that stores the callback function and the original
+context in a struct, then uses UA_Log_Pascal_log to dispatch the messages
+*/
+SYM_EXPORT UA_Logger UA_Pascal_logger(void *context, pascal_log_t func) {
+        PascalLogTrampoline *trampoline=malloc(sizeof(trampoline));
+        trampoline->context = context;
+        trampoline->func = func;
+        UA_Logger logger = {UA_Log_Pascal_log, (void *)trampoline, UA_Log_Pascal_clear};
+        return logger;
+}

--- a/pascallog/pascallog.cbp
+++ b/pascallog/pascallog.cbp
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="ua_pascallog" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Release">
+				<Option output="ua_pascallog" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="bin/Release" />
+				<Option object_output="obj/Release/" />
+				<Option type="3" />
+				<Option compiler="gcc" />
+				<Option createDefFile="1" />
+				<Compiler>
+					<Add option="-Wall" />
+					<Add option="-Og" />
+					<Add option="-g" />
+				</Compiler>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-g" />
+			<Add directory="D:/open62541/open62541-win32/include" />
+		</Compiler>
+		<Unit filename="pascallog.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Extensions>
+			<code_completion />
+			<envvars />
+			<debugger />
+			<lib_finder disable_auto="1" />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>


### PR DESCRIPTION
These are my changes to the original headers:

- most parameters changed from PAnsiChar to AnsiString (it's more pascalish this way)
- this way we can embed 0 bytes in a UA_String/UA_ByteString
- the non allocating functions use **var** parameter (to trigger an error if one tries to use a property) while the allocating ones use **const**
- added a default build mode to the test program and other small fixes
- added functions to create/free BrowseRequest/BrowseResponse/BrowseDescription
- added a C dll to redirect log messages to pascal code

I tested these under win32 and linux/64.